### PR TITLE
Prevent incorrect start of a new fuel cycle in Reactor (#515)

### DIFF
--- a/src/reactor.cc
+++ b/src/reactor.cc
@@ -356,8 +356,11 @@ void Reactor::Tock() {
   if (retired()) {
     return;
   }
-
-  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core) {
+  
+  // Check that irradiation and refueling periods are over, that 
+  // the core is full and that fuel was successfully discharged in this refueling time.
+  // If this is the case, then a new cycle will be initiated.
+  if (cycle_step >= cycle_time + refuel_time && core.count() == n_assem_core && discharged == true) {
     discharged = false;
     cycle_step = 0;
   }


### PR DESCRIPTION
* Prevent start of a new cycle if core has not been discharged

The if-condition leading to `cycle_step` being reset to 0 and subsequently
initiating the start of a new cycle has been changed to avoid erroneous
behaviour.

If the spent fuel inventory is of size zero or if it is full in between
time `cycle_time` and `cycle_time + refuel_time`, then the core cannot
be discharged in `Reactor::Tick()` and `discharged` remains set to false.

In `Reactor::Tock()`, this leads to `core.count() == n_assem_core`
evaluating to true and if `cycle_step` is larger or equal than
`cycle_time + refuel_time`, then `cycle_step` gets reset to 0 and a new
cycle will (wrongly) start with a full core composed at least partially
of spent fuel.

The additional boolean expression prevents this behaviour by checking if
the core has been discharged before resetting `cycle_step`.

* Add reactor-shutdown test if spent fuel storage full

This commit adds a test to assure that the reactor gets shutdown and
does not generate power anymore when the spent fuel storage is full
and the core cannot be unloaded.

See commit https://github.com/maxschalz/cycamore/commit/9c3e52468b6c59db4793c8e630317c04063ce6a9 for more information
on the problem of power generation and a full spent fuel storage.

* Revert change in .gitignore to coincide with cycamore .gitignore

* Add comment to clarify when a new cycle will start

* Update src/reactor.cc

Co-Authored-By: Paul Wilson <paul.wilson@wisc.edu>

Co-authored-by: Paul Wilson <paul.wilson@wisc.edu>